### PR TITLE
Fix wizard layout on system with a different default font.

### DIFF
--- a/Wizard/UI/ConfiguratorForm.Designer.cs
+++ b/Wizard/UI/ConfiguratorForm.Designer.cs
@@ -373,6 +373,7 @@
             this.ClientSize = new System.Drawing.Size(446, 370);
             this.Controls.Add(this.splitCon);
             this.Controls.Add(this.panelTop);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.MaximizeBox = false;
             this.MinimizeBox = false;

--- a/Wizard/UI/Controls/ProgressLineControl.Designer.cs
+++ b/Wizard/UI/Controls/ProgressLineControl.Designer.cs
@@ -22,6 +22,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.DeepSkyBlue;
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.Name = "ProgressLineControl";
             this.Size = new System.Drawing.Size(195, 10);
             this.ResumeLayout(false);

--- a/Wizard/UI/Controls/ProjectItemControl.Designer.cs
+++ b/Wizard/UI/Controls/ProjectItemControl.Designer.cs
@@ -598,6 +598,7 @@ namespace net.r_eg.DllExport.Wizard.UI.Controls
             this.Controls.Add(this.panelStatus);
             this.Controls.Add(this.gbProject);
             this.Controls.Add(this.groupNS);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.Name = "ProjectItemControl";
             this.Size = new System.Drawing.Size(444, 231);
             ((System.ComponentModel.ISupportInitialize)(this.numOrdinal)).EndInit();

--- a/Wizard/UI/Controls/ProjectItemsControl.Designer.cs
+++ b/Wizard/UI/Controls/ProjectItemsControl.Designer.cs
@@ -32,6 +32,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.panelMain);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.Name = "ProjectItemsControl";
             this.Size = new System.Drawing.Size(73, 43);
             this.ResumeLayout(false);

--- a/Wizard/UI/MsgForm.Designer.cs
+++ b/Wizard/UI/MsgForm.Designer.cs
@@ -98,6 +98,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(599, 241);
             this.Controls.Add(this.listBoxLog);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
             this.Name = "MsgForm";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;


### PR DESCRIPTION
Fix wizard on system with a different default font from "Microsoft Sans Serif". Close #61 

![image](https://user-images.githubusercontent.com/11240579/71036087-e10fc580-2157-11ea-8485-8901e85cf8b5.png)
![image](https://user-images.githubusercontent.com/11240579/71036328-6f844700-2158-11ea-968a-293e6fb909f4.png)

Overlay [your screenshot](https://github.com/3F/DllExport/issues/61#issuecomment-566519504) on top, seems identical.
![image](https://user-images.githubusercontent.com/11240579/71036192-23390700-2158-11ea-956b-ca5effdf0cfa.png)
