### PR TITLE
Adds Pre-Processing feature. Related issue #40

### DIFF
--- a/Wizard/Executor.cs
+++ b/Wizard/Executor.cs
@@ -31,6 +31,7 @@ using net.r_eg.DllExport.NSBin;
 using net.r_eg.DllExport.Wizard.Extensions;
 using net.r_eg.MvsSln;
 using net.r_eg.MvsSln.Core;
+using net.r_eg.MvsSln.Extensions;
 using net.r_eg.MvsSln.Log;
 
 namespace net.r_eg.DllExport.Wizard

--- a/Wizard/Extensions/CollectionExtension.cs
+++ b/Wizard/Extensions/CollectionExtension.cs
@@ -24,10 +24,11 @@
 
 using System;
 using System.Collections.Generic;
+using net.r_eg.MvsSln.Extensions;
 
 namespace net.r_eg.DllExport.Wizard.Extensions
 {
-    public static class CollectionExtension
+    internal static class CollectionExtension
     {
         /// <summary>
         /// Foreach in Linq manner.
@@ -35,27 +36,9 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <typeparam name="T"></typeparam>
         /// <param name="items"></param>
         /// <param name="act">The action that should be executed for each item.</param>
-        public static IEnumerable<T> ForEach<T>(this IEnumerable<T> items, Action<T> act)
+        public static IEnumerable<T> Each<T>(this IEnumerable<T> items, Action<T> act)
         {
-            return items?.ForEach((x, i) => act(x));
-        }
-
-        /// <summary>
-        /// Foreach in Linq manner.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="items"></param>
-        /// <param name="act">The action that should be executed for each item.</param>
-        public static IEnumerable<T> ForEach<T>(this IEnumerable<T> items, Action<T, long> act)
-        {
-            if(items == null) {
-                return null;
-            }
-
-            long n = 0;
-            foreach(var item in items) {
-                act(item, n++);
-            }
+            items?.ForEach((x, i) => act(x));
             return items;
         }
 
@@ -69,7 +52,7 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <returns></returns>
         public static IEnumerable<string> Combine(this IEnumerable<string> items, string elem, bool before = false)
         {
-            if(before && !String.IsNullOrEmpty(elem)) {
+            if(before && !string.IsNullOrEmpty(elem)) {
                 yield return elem;
             }
 
@@ -77,7 +60,7 @@ namespace net.r_eg.DllExport.Wizard.Extensions
                 yield return item;
             }
 
-            if(!before && !String.IsNullOrEmpty(elem)) {
+            if(!before && !string.IsNullOrEmpty(elem)) {
                 yield return elem;
             }
         }

--- a/Wizard/Extensions/StringExtension.cs
+++ b/Wizard/Extensions/StringExtension.cs
@@ -24,8 +24,6 @@
 
 using System;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace net.r_eg.DllExport.Wizard.Extensions
 {
@@ -38,7 +36,7 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <returns></returns>
         public static bool ToBoolean(this string value)
         {
-            if(String.IsNullOrWhiteSpace(value)) {
+            if(string.IsNullOrWhiteSpace(value)) {
                 return false;
             }
 
@@ -67,7 +65,7 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <returns></returns>
         public static int ToInteger(this string value)
         {
-            if(String.IsNullOrWhiteSpace(value)) {
+            if(string.IsNullOrWhiteSpace(value)) {
                 return 0;
             }
 
@@ -81,7 +79,7 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <returns></returns>
         public static long ToLongInteger(this string value)
         {
-            if(String.IsNullOrWhiteSpace(value)) {
+            if(string.IsNullOrWhiteSpace(value)) {
                 return 0;
             }
 
@@ -94,44 +92,17 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <param name="url"></param>
         public static void OpenUrl(this string url)
         {
-            if(!String.IsNullOrWhiteSpace(url)) {
+            if(!string.IsNullOrWhiteSpace(url)) {
                 System.Diagnostics.Process.Start(url);
             }
         }
 
-        /// <summary>
-        /// Calculate SHA-1 hash from file.
-        /// </summary>
-        /// <param name="file">Path to file.</param>
-        /// <returns>SHA-1 Hash code.</returns>
-        public static string SHA1HashFromFile(this string file)
+        internal static bool CmpPublicKeyTokenWith(this string pkToken, string pkTokenAsm)
         {
-            using(var fs = File.OpenRead(file))
-            {
-                using(SHA1 sha1 = SHA1.Create()) {
-                    return BytesToHexView(sha1.ComputeHash(fs));
-                }
+            if(pkTokenAsm == null || string.IsNullOrWhiteSpace(pkToken)) {
+                return false;
             }
-        }
-
-        /// <summary>
-        /// To add postfix to filename.
-        /// </summary>
-        /// <param name="fname">Filename or path to file with extension or without.</param>
-        /// <param name="postfix"></param>
-        /// <returns></returns>
-        public static string AddFileNamePostfix(this string fname, string postfix)
-        {
-            if(String.IsNullOrWhiteSpace(fname) || String.IsNullOrWhiteSpace(postfix)) {
-                return fname;
-            }
-
-            int idx = fname.LastIndexOf('.');
-            if(idx == -1) {
-                return fname + postfix;
-            }
-
-            return fname.Insert(idx, postfix);
+            return pkToken.Equals(pkTokenAsm, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>
@@ -141,7 +112,7 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <returns></returns>
         public static string OpenDoubleQuotes(this string value)
         {
-            if(String.IsNullOrWhiteSpace(value)) {
+            if(string.IsNullOrWhiteSpace(value)) {
                 return value;
             }
 
@@ -183,31 +154,17 @@ namespace net.r_eg.DllExport.Wizard.Extensions
         /// <param name="path"></param>
         /// <param name="root"></param>
         /// <returns></returns>
-        public static string CombineRootPath(string path, string root)
+        private static string CombineRootPath(string path, string root)
         {
-            if(String.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path)) {
+            if(string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path)) {
                 return path;
             }
 
-            if(String.IsNullOrWhiteSpace(root)) {
+            if(string.IsNullOrWhiteSpace(root)) {
                 return path;
             }
 
             return Path.Combine(root, path);
-        }
-
-        /// <summary>
-        /// To format bytes data to hex view.
-        /// </summary>
-        /// <param name="data">Bytes data.</param>
-        /// <returns>Hex view of bytes.</returns>
-        private static string BytesToHexView(byte[] data)
-        {
-            var ret = new StringBuilder();
-            foreach(byte b in data) {
-                ret.Append(b.ToString("X2"));
-            }
-            return ret.ToString();
         }
     }
 }

--- a/Wizard/Extensions/XProjectExtension.cs
+++ b/Wizard/Extensions/XProjectExtension.cs
@@ -74,5 +74,16 @@ namespace net.r_eg.DllExport.Wizard.Extensions
             )
             .Guid();
         }
+
+        public static void AddPackageIfNotExists(this IXProject xp, string id, string version)
+        {
+            if(xp == null) {
+                throw new ArgumentNullException(nameof(xp)); 
+            }
+
+            if(xp.GetFirstPackageReference(id ?? throw new ArgumentNullException(nameof(id))).parentItem == null) {
+                xp.AddPackageReference(id, version);
+            }
+        }
     }
 }

--- a/Wizard/Gears/IProjectGear.cs
+++ b/Wizard/Gears/IProjectGear.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016-2020  Denis Kuzmin < x-3F@outlook.com > GitHub/3F
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+namespace net.r_eg.DllExport.Wizard.Gears
+{
+    internal interface IProjectGear
+    {
+        void Install();
+
+        void Uninstall(bool hardReset);
+    }
+}

--- a/Wizard/Gears/PreProcGear.cs
+++ b/Wizard/Gears/PreProcGear.cs
@@ -1,0 +1,260 @@
+﻿/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016-2020  Denis Kuzmin < x-3F@outlook.com > GitHub/3F
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Construction;
+using net.r_eg.DllExport.Wizard.Extensions;
+using net.r_eg.MvsSln.Core;
+using net.r_eg.MvsSln.Log;
+using static net.r_eg.DllExport.Wizard.PreProc;
+
+namespace net.r_eg.DllExport.Wizard.Gears
+{
+    internal sealed class PreProcGear: IProjectGear
+    {
+        private const string ILMERGE_TMP = ".ilm0";
+
+        private readonly Version incConari = new Version("1.4.0");
+        private readonly Version incILMerge = new Version("3.0.29");
+
+        private readonly IProjectSvc prj;
+        private readonly ProjectPropertyGroupElement pgroup;
+
+        private IUserConfig Config => prj.Config;
+        private IXProject XProject => prj.XProject;
+        private ISender Log => Config.Log;
+
+        public void Install() => CfgPreProc();
+
+        public void Uninstall(bool hardReset) => RemovePreProcTarget(hardReset);
+
+        public PreProcGear(IProjectSvc prj)
+        {
+            this.prj    = prj ?? throw new ArgumentNullException(nameof(prj));
+            pgroup      = XProject.Project.Xml.AddPropertyGroup();
+        }
+
+        private void CfgPreProc()
+        {
+            CmdType type = Config.PreProc.Type;
+
+            prj.SetProperty(MSBuildProperties.DXP_PRE_PROC_TYPE, (long)type);
+            Log.send(this, $"Pre-Processing type: {type}");
+
+            if(type == CmdType.None) {
+                return;
+            }
+
+            var sb = new _MixStringBuilder(5);
+
+            if((type & CmdType.Conari) == CmdType.Conari)
+            {
+                Log.send(this, $"Integrate Conari: {incConari}");
+                XProject.AddPackageIfNotExists("Conari", $"{incConari}");
+                sb.AppendBoth("Conari.dll ");
+
+                // .NET Core
+                sb.AppendCor("Microsoft.CSharp.dll System.Reflection.Emit.dll ");
+                sb.AppendCor("System.Reflection.Emit.ILGeneration.dll System.Reflection.Emit.Lightweight.dll ");
+                OverrideCopyLocalLockFileAssemblies();
+            }
+
+            if((type & CmdType.ILMerge) == CmdType.ILMerge)
+            {
+                prj.SetProperty(MSBuildProperties.DXP_ILMERGE, Config.PreProc.Cmd);
+                Log.send(this, $"Merge modules via ILMerge {incILMerge}: {Config.PreProc.Cmd}");
+
+                XProject.AddPackageIfNotExists("ilmerge", $"{incILMerge}");
+                sb.AppendBoth($"{Config.PreProc.Cmd} ");
+            }
+
+            if((type & CmdType.Exec) == CmdType.Exec)
+            {
+                Log.send(this, $"Pre-Processing command: {Config.PreProc.Cmd}");
+                sb.AppendBoth($"{Config.PreProc.Cmd} ");
+            }
+
+            AddPreProcTarget(
+                FormatPreProcCmd(type, sb.Fx),
+                FormatPreProcCmd(type, sb.Cor),
+                type
+            );
+        }
+
+        private void AddPreProcTarget(string fxCmd, string corCmd, CmdType type)
+        {
+            var target = prj.AddTarget(MSBuildTargets.DXP_PRE_PROC);
+
+            target.BeforeTargets = MSBuildTargets.DXP_MAIN;
+            target.Label = Project.METALIB_PK_TOKEN;
+
+            var tCopy = target.AddTask("Copy");
+            tCopy.SetParameter("SourceFiles", $"$({MSBuildProperties.DXP_METALIB_FPATH})");
+            tCopy.SetParameter("DestinationFolder", $"$({MSBuildProperties.PRJ_TARGET_DIR})");
+            tCopy.SetParameter("SkipUnchangedFiles", "true");
+            tCopy.SetParameter("OverwriteReadOnlyFiles", "true");
+
+            bool ignoreErr = (type & CmdType.IgnoreErr) == CmdType.IgnoreErr;
+            ProjectTaskElement tExec;
+
+            if(corCmd != fxCmd)
+            {
+                tExec = AddExecTask(target, fxCmd, "'$(IsNetCoreBased)'!='true'", ignoreErr);
+                        AddExecTask(target, corCmd, "'$(IsNetCoreBased)'=='true'", ignoreErr);
+            }
+            else
+            {
+                tExec = AddExecTask(target, fxCmd, null, ignoreErr);
+            }
+
+            if((type & CmdType.DebugInfo) == CmdType.DebugInfo)
+            {
+                OverrideDebugType();
+                AddPreProcAfterTarget(target, tExec);
+            }
+
+            var tDelete = target.AddTask("Delete");
+            tDelete.SetParameter("Files", $"$({MSBuildProperties.PRJ_TARGET_DIR})$({MSBuildProperties.DXP_METALIB_NAME})");
+            tDelete.ContinueOnError = "true";
+        }
+
+        private void AddPreProcAfterTarget(ProjectTargetElement ppTarget, ProjectTaskElement tExec)
+        {
+            var tMove = ppTarget.AddTask("Move");
+            tMove.SetParameter("SourceFiles", $"$({MSBuildProperties.PRJ_TARGET_DIR})$({MSBuildProperties.PRJ_TARGET_F}){ILMERGE_TMP}.dll");
+            tMove.SetParameter("DestinationFiles", $"$({MSBuildProperties.PRJ_TARGET_DIR})$({MSBuildProperties.PRJ_TARGET_F})");
+            tMove.SetParameter("OverwriteReadOnlyFiles", "true");
+            tMove.ContinueOnError = tExec.ContinueOnError;
+
+            var target = prj.AddTarget(MSBuildTargets.DXP_PRE_PROC_AFTER);
+            target.AfterTargets = MSBuildTargets.DXP_MAIN;
+            target.Label = Project.METALIB_PK_TOKEN;
+
+            var tDelete = target.AddTask("Delete");
+            tDelete.SetParameter("Files", $"$({MSBuildProperties.PRJ_TARGET_DIR})$({MSBuildProperties.PRJ_TARGET_F}){ILMERGE_TMP}.pdb");
+            tDelete.ContinueOnError = "true";
+        }
+
+        private ProjectTaskElement AddExecTask(ProjectTargetElement target, string cmd, string condition, bool continueOnError)
+        {
+            var tExec = target.AddTask("Exec");
+            tExec.Condition = condition;
+            tExec.SetParameter("Command", cmd ?? throw new ArgumentNullException(nameof(cmd)));
+            tExec.SetParameter("WorkingDirectory", $"$({MSBuildProperties.PRJ_TARGET_DIR})");
+            tExec.ContinueOnError = continueOnError.ToString().ToLower();
+
+            return tExec;
+        }
+
+        private void RemovePreProcTarget(bool hardReset)
+        {
+            Log.send(this, $"Trying to remove pre-proc-targets: `{MSBuildTargets.DXP_PRE_PROC}`, `{MSBuildTargets.DXP_PRE_PROC_AFTER}`", Message.Level.Info);
+            while(prj.RemoveXmlTarget(MSBuildTargets.DXP_PRE_PROC)) { }
+            while(prj.RemoveXmlTarget(MSBuildTargets.DXP_PRE_PROC_AFTER)) { }
+
+            if(hardReset)
+            {
+                while(RemoveCopyLocalLockFileAssemblies()) { }
+                while(RemoveOverridedDebugType()) { }
+            }
+        }
+
+        private string FormatPreProcCmd(CmdType type, StringBuilder sb)
+        {
+            string cmd = sb?.ToString().TrimEnd();
+
+            if((type & CmdType.ILMerge) == CmdType.ILMerge)
+            {
+                return $"$(ILMergeConsolePath) {cmd} $(TargetFileName) /out:$(TargetFileName)" 
+                        + (((type & CmdType.DebugInfo) == 0) ? " /ndebug" : $"{ILMERGE_TMP}.dll");
+            }
+            return cmd;
+        }
+
+        private void OverrideCopyLocalLockFileAssemblies()
+        {
+            var prop = pgroup.SetProperty(MSBuildProperties.PRJ_CP_LOCKFILE_ASM, "true");
+            prop.Condition = "$(TargetFramework.StartsWith('netc')) Or $(TargetFramework.StartsWith('nets'))";
+            prop.Label = Project.METALIB_PK_TOKEN;
+        }
+
+        private bool RemoveCopyLocalLockFileAssemblies() => RemoveLabeledProperty(MSBuildProperties.PRJ_CP_LOCKFILE_ASM);
+
+        private void OverrideDebugType()
+        {
+            var prop = pgroup.SetProperty(MSBuildProperties.PRJ_DBG_TYPE, "pdbonly");
+            prop.Condition = "'$(DebugType)'!='full'";
+            prop.Label = Project.METALIB_PK_TOKEN;
+        }
+
+        private bool RemoveOverridedDebugType() => RemoveLabeledProperty(MSBuildProperties.PRJ_DBG_TYPE);
+
+        private bool RemoveLabeledProperty(string name)
+        {
+            // access to properties without evaluating the condition attribute
+            ProjectPropertyElement _Get() => XProject.Project.Xml.Properties
+                                            .FirstOrDefault(p => p.Name == name && p.Label == Project.METALIB_PK_TOKEN);
+
+            var pp = _Get();
+            if(pp?.Parent == null) {
+                return false;
+            }
+
+            if(pp.Parent.Children.Count <= 1 && pp.Parent.Parent != null)
+            {
+                //TODO: but for sdk-style it still can leave an empty <PropertyGroup /> due to msbuild bug
+                pp.Parent.Parent.RemoveChild(pp.Parent);
+            }
+            else
+            {
+                pp.Parent.RemoveChild(pp);
+            }
+
+            return _Get() != null;
+        }
+
+        private sealed class _MixStringBuilder
+        {
+            public StringBuilder Fx { get; private set; }
+            public StringBuilder Cor { get; private set; }
+
+            public void AppendBoth(string value)
+            {
+                AppendFx(value);
+                AppendCor(value);
+            }
+
+            public StringBuilder AppendFx(string value) => Fx.Append(value);
+            public StringBuilder AppendCor(string value) => Cor.Append(value);
+
+            public _MixStringBuilder(int capacity)
+            {
+                Fx  = new StringBuilder(capacity);
+                Cor = new StringBuilder(capacity);
+            }
+        }
+    }
+}

--- a/Wizard/IProjectSvc.cs
+++ b/Wizard/IProjectSvc.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016-2020  Denis Kuzmin < x-3F@outlook.com > GitHub/3F
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+using Microsoft.Build.Construction;
+
+namespace net.r_eg.DllExport.Wizard
+{
+    internal interface IProjectSvc: IProject
+    {
+        ProjectTargetElement AddTarget(string name);
+
+        bool RemoveXmlTarget(string name);
+
+        void SetProperty(string name, string value);
+
+        void SetProperty(string name, bool val);
+
+        void SetProperty(string name, int val);
+
+        void SetProperty(string name, long val);
+    }
+}

--- a/Wizard/MSBuildProperties.cs
+++ b/Wizard/MSBuildProperties.cs
@@ -139,6 +139,8 @@ namespace net.r_eg.DllExport.Wizard
 
         public const string PRJ_DBG_TYPE = "DebugType";
 
+        public const string PRJ_CP_LOCKFILE_ASM = "CopyLocalLockFileAssemblies";
+
         public const string SLN_DIR = "SolutionDir";
     }
 }

--- a/Wizard/MSBuildProperties.cs
+++ b/Wizard/MSBuildProperties.cs
@@ -117,5 +117,28 @@ namespace net.r_eg.DllExport.Wizard
         /// Platform for DllExport tool.
         /// </summary>
         public const string DXP_PLATFORM = "DllExportPlatform";
+
+        /// <summary>
+        /// Used Pre-Processing type.
+        /// </summary>
+        public const string DXP_PRE_PROC_TYPE = "DllExportPreProcType";
+
+        /// <summary>
+        /// List of modules for ILMerge if used.
+        /// </summary>
+        public const string DXP_ILMERGE = "DllExportILMerge";
+
+        /// <summary>
+        /// Meta library full path to file.
+        /// </summary>
+        public const string DXP_METALIB_FPATH = "DllExportMetaLibFullPath";
+
+        public const string PRJ_TARGET_DIR = "TargetDir";
+
+        public const string PRJ_TARGET_F = "TargetFileName";
+
+        public const string PRJ_DBG_TYPE = "DebugType";
+
+        public const string SLN_DIR = "SolutionDir";
     }
 }

--- a/Wizard/MSBuildTargets.cs
+++ b/Wizard/MSBuildTargets.cs
@@ -22,74 +22,39 @@
  * THE SOFTWARE.
 */
 
-using System.Collections.Generic;
-using net.r_eg.DllExport.NSBin;
-using net.r_eg.MvsSln.Log;
-
 namespace net.r_eg.DllExport.Wizard
 {
-    public interface IUserConfig
+    internal struct MSBuildTargets
     {
         /// <summary>
-        /// Flag of installation.
+        /// The name of target to restore package.
         /// </summary>
-        bool Install { get; set; }
+        internal const string DXP_PKG_R = "DllExportRestorePkg";
 
         /// <summary>
-        /// A selected namespace for ddNS feature.
+        /// Pre-Processing.
         /// </summary>
-        string Namespace { get; set; }
+        internal const string DXP_PRE_PROC = "DllExportPreProc";
 
         /// <summary>
-        /// Allowed buffer size for NS.
+        /// Post-Actions of the main Pre-Processing.
         /// </summary>
-        int NSBuffer { get; set; }
+        internal const string DXP_PRE_PROC_AFTER = "DllExportPreProcAfter";
 
         /// <summary>
-        /// To use Cecil instead of direct modifications.
+        /// To support dynamic `import` section.
+        /// https://github.com/3F/DllExport/issues/62
         /// </summary>
-        bool UseCecil { get; set; }
+        internal const string DXP_R_DYN = "DllExportRPkgDynamicImport";
 
         /// <summary>
-        /// Predefined list of namespaces.
+        /// The entry point of the main task.
         /// </summary>
-        List<string> Namespaces { get; set; }
+        internal const string DXP_MAIN = "DllExportMod";
 
         /// <summary>
-        /// Access to wizard configuration.
+        /// Flag when imported the {DXP_MAIN} target.
         /// </summary>
-        IWizardConfig Wizard { get; set; }
-
-        /// <summary>
-        /// Access to ddNS core.
-        /// </summary>
-        IDDNS DDNS { get; set; }
-
-        /// <summary>
-        /// Specific logger.
-        /// </summary>
-        ISender Log { get; set; }
-
-        /// <summary>
-        /// Platform target for project.
-        /// </summary>
-        Platform Platform { get; set; }
-
-        /// <summary>
-        /// Settings for ILasm etc.
-        /// </summary>
-        CompilerCfg Compiler { get; set; }
-
-        /// <summary>
-        /// Access to Pre-Processing.
-        /// </summary>
-        PreProc PreProc { get; set; }
-
-        /// <summary>
-        /// Adds to top new namespace into Namespaces property.
-        /// </summary>
-        /// <param name="ns"></param>
-        /// <returns>true if added.</returns>
-        bool AddTopNamespace(string ns);
+        internal const string DXP_MAIN_FLAG = "DllExportModImported";
     }
 }

--- a/Wizard/PreProc.cs
+++ b/Wizard/PreProc.cs
@@ -1,0 +1,68 @@
+﻿/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016-2020  Denis Kuzmin < x-3F@outlook.com > GitHub/3F
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+namespace net.r_eg.DllExport.Wizard
+{
+    public sealed class PreProc
+    {
+        /// <summary>
+        /// Never null command.
+        /// </summary>
+        public string Cmd
+        {
+            get;
+            private set;
+        }
+
+        public CmdType Type
+        {
+            get;
+            private set;
+        }
+
+        [System.Flags]
+        public enum CmdType: long
+        {
+            None        = 0x0,
+
+            ILMerge     = 0x1,
+
+            Conari      = 0x2,
+
+            Exec        = 0x4,
+
+            DebugInfo   = 0x8,
+
+            IgnoreErr   = 0x10,
+        }
+
+        public PreProc Configure(CmdType type = CmdType.None, string cmd = null)
+        {
+            Type    = type;
+            Cmd     = (type == CmdType.None || cmd == null) ? string.Empty : cmd;
+
+            return this;
+        }
+    }
+}

--- a/Wizard/UI/ConfiguratorForm.Designer.cs
+++ b/Wizard/UI/ConfiguratorForm.Designer.cs
@@ -59,6 +59,8 @@
             this.tabCtrl = new System.Windows.Forms.TabControl();
             this.tabCfgDxp = new System.Windows.Forms.TabPage();
             this.projectItems = new net.r_eg.DllExport.Wizard.UI.Controls.ProjectItemsControl();
+            this.tabPreProc = new System.Windows.Forms.TabPage();
+            this.preProcControl = new net.r_eg.DllExport.Wizard.UI.Controls.PreProcControl();
             this.tabData = new System.Windows.Forms.TabPage();
             this.labelStorage = new System.Windows.Forms.Label();
             this.txtCfgData = new System.Windows.Forms.TextBox();
@@ -83,6 +85,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.dgvFilter)).BeginInit();
             this.tabCtrl.SuspendLayout();
             this.tabCfgDxp.SuspendLayout();
+            this.tabPreProc.SuspendLayout();
             this.tabData.SuspendLayout();
             this.tabUpdating.SuspendLayout();
             this.panelUpdVerTop.SuspendLayout();
@@ -296,6 +299,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabCtrl.Appearance = System.Windows.Forms.TabAppearance.Buttons;
             this.tabCtrl.Controls.Add(this.tabCfgDxp);
+            this.tabCtrl.Controls.Add(this.tabPreProc);
             this.tabCtrl.Controls.Add(this.tabData);
             this.tabCtrl.Controls.Add(this.tabUpdating);
             this.tabCtrl.Controls.Add(this.tabBuildInfo);
@@ -333,6 +337,24 @@
             this.projectItems.OpenUrl = null;
             this.projectItems.Size = new System.Drawing.Size(448, 247);
             this.projectItems.TabIndex = 2;
+            // 
+            // tabPreProc
+            // 
+            this.tabPreProc.Controls.Add(this.preProcControl);
+            this.tabPreProc.Location = new System.Drawing.Point(4, 25);
+            this.tabPreProc.Name = "tabPreProc";
+            this.tabPreProc.Size = new System.Drawing.Size(442, 230);
+            this.tabPreProc.TabIndex = 4;
+            this.tabPreProc.Text = "Pre-Processing";
+            this.tabPreProc.UseVisualStyleBackColor = true;
+            // 
+            // preProcControl
+            // 
+            this.preProcControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.preProcControl.Location = new System.Drawing.Point(0, 0);
+            this.preProcControl.Name = "preProcControl";
+            this.preProcControl.Size = new System.Drawing.Size(442, 230);
+            this.preProcControl.TabIndex = 0;
             // 
             // tabData
             // 
@@ -542,6 +564,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.dgvFilter)).EndInit();
             this.tabCtrl.ResumeLayout(false);
             this.tabCfgDxp.ResumeLayout(false);
+            this.tabPreProc.ResumeLayout(false);
             this.tabData.ResumeLayout(false);
             this.tabData.PerformLayout();
             this.tabUpdating.ResumeLayout(false);
@@ -588,5 +611,7 @@
         private System.Windows.Forms.ComboBox comboBoxStorage;
         private System.Windows.Forms.TextBox txtCfgData;
         private System.Windows.Forms.Label labelSrcMit;
+        private System.Windows.Forms.TabPage tabPreProc;
+        private Controls.PreProcControl preProcControl;
     }
 }

--- a/Wizard/UI/ConfiguratorForm.Designer.cs
+++ b/Wizard/UI/ConfiguratorForm.Designer.cs
@@ -19,15 +19,11 @@
             fdialog?.Dispose();
             icons?.Dispose();
 
-            ctsUpdater?.Cancel();
-
-            if(tUpdater != null)
+            if(ctsUpdater != null)
             {
-                tUpdater.Wait();
-                tUpdater.Dispose();
+                ctsUpdater.Cancel();
+                ctsUpdater.Dispose();
             }
-            ctsUpdater?.Dispose();
-
             base.Dispose(disposing);
         }
 
@@ -207,10 +203,10 @@
             // 
             this.panelPrjs.Controls.Add(this.dgvFilter);
             this.panelPrjs.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelPrjs.Location = new System.Drawing.Point(0, 26);
+            this.panelPrjs.Location = new System.Drawing.Point(0, 19);
             this.panelPrjs.Margin = new System.Windows.Forms.Padding(0);
             this.panelPrjs.Name = "panelPrjs";
-            this.panelPrjs.Size = new System.Drawing.Size(446, 52);
+            this.panelPrjs.Size = new System.Drawing.Size(446, 59);
             this.panelPrjs.TabIndex = 2;
             // 
             // dgvFilter
@@ -250,7 +246,7 @@
             this.dgvFilter.RowTemplate.Height = 17;
             this.dgvFilter.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.dgvFilter.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvFilter.Size = new System.Drawing.Size(446, 52);
+            this.dgvFilter.Size = new System.Drawing.Size(446, 59);
             this.dgvFilter.TabIndex = 0;
             this.dgvFilter.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvFilter_RowEnter);
             this.dgvFilter.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dgvFilter_KeyDown);
@@ -289,7 +285,7 @@
             this.panelFilter.Location = new System.Drawing.Point(0, 0);
             this.panelFilter.Margin = new System.Windows.Forms.Padding(0);
             this.panelFilter.Name = "panelFilter";
-            this.panelFilter.Size = new System.Drawing.Size(446, 26);
+            this.panelFilter.Size = new System.Drawing.Size(446, 19);
             this.panelFilter.TabIndex = 1;
             // 
             // tabCtrl

--- a/Wizard/UI/ConfiguratorForm.cs
+++ b/Wizard/UI/ConfiguratorForm.cs
@@ -55,7 +55,8 @@ namespace net.r_eg.DllExport.Wizard.UI
         private readonly Caller caller;
         private readonly PackageInfo pkgVer;
         private readonly IConfFormater confFormater;
-        private int prevSlnItemIndex = 0;
+        private volatile int prevSlnItemIndex = 0;
+        private volatile int prevPrjIndex = -1;
         private volatile bool _suspendCbSln;
         private readonly string updaterInitName;
         private CancellationTokenSource ctsUpdater;
@@ -69,10 +70,7 @@ namespace net.r_eg.DllExport.Wizard.UI
         /// To apply filter for rendered projects.
         /// </summary>
         /// <param name="filter"></param>
-        public void ApplyFilter(ProjectFilter filter)
-        {
-            RenderProjects(exec.ActiveSlnFile, filter);
-        }
+        public void ApplyFilter(ProjectFilter filter) => RenderProjects(exec.ActiveSlnFile, filter);
 
         public void ShowProgressLine(bool enabled)
         {
@@ -113,23 +111,6 @@ namespace net.r_eg.DllExport.Wizard.UI
             storage.UpdateItem();
 
             projectItems.Set(null); // TODO: this only when no projects in solution and only when initial start
-        }
-
-        private void ConfiguratorForm_Load(object sender, EventArgs e)
-        {
-            TopMost = false; TopMost = true;
-
-            if(!string.IsNullOrEmpty(pkgVer.Activated))
-            {
-                UpdateListOfPackages();
-                txtLogUpd.SetData($"{CmdUpdate} ...");
-            }
-            else
-            {
-                panelUpdVerTop.Enabled = false;
-                btnToOnline.Visible = true;
-                txtLogUpd.SetData("You're using an offline version or such `-dxp-version actual`.");
-            }
         }
 
         private void UpdateListOfPackages()
@@ -413,6 +394,42 @@ namespace net.r_eg.DllExport.Wizard.UI
             ));
         }
 
+        private void UpdateRefBefore(IProject prj)
+        {
+            preProcControl.Export(prj.Config.PreProc);
+            //TODO: to change processing of projectItems to this way
+        }
+
+        private void UpdateRefAfter(IProject prj)
+        {
+            //TODO: multiple controls are obsolete now because of new layout in 1.7+
+            projectItems.Pause();
+            projectItems.Set(prj);
+            projectItems.Resume();
+
+            preProcControl.Render(prj.Config.PreProc);
+
+            txtCfgData.Text = confFormater.Parse(prj);
+        }
+
+        private IProject GetProject(int index)
+        {
+            if(index == -1 || index >= dgvFilter.RowCount) {
+                return null;
+            }
+
+            string path = dgvFilter.Rows[index].Cells[gcPath.Name].Value.ToString();
+            return GetProjects(exec.ActiveSlnFile).FirstOrDefault(p => p.ProjectPath == path);
+        }
+
+        private void UpdateRefBefore()
+        {
+            IProject prevPrj = GetProject(prevPrjIndex);
+            if(prevPrj != null) {
+                UpdateRefBefore(prevPrj);
+            }
+        }
+
         private void EnableTabsWhenNoSln(bool status) => ((Control)tabCfgDxp).Enabled = status;
 
         private string GetBuildInfo()
@@ -438,6 +455,23 @@ namespace net.r_eg.DllExport.Wizard.UI
             return sb.ToString();
         }
 
+        private void ConfiguratorForm_Load(object sender, EventArgs e)
+        {
+            TopMost = false; TopMost = true;
+
+            if(!string.IsNullOrEmpty(pkgVer.Activated))
+            {
+                UpdateListOfPackages();
+                txtLogUpd.SetData($"{CmdUpdate} ...");
+            }
+            else
+            {
+                panelUpdVerTop.Enabled = false;
+                btnToOnline.Visible = true;
+                txtLogUpd.SetData("You're using an offline version or such `-dxp-version actual`.");
+            }
+        }
+
         private void comboBoxSln_SelectedIndexChanged(object sender, EventArgs e)
         {
             if(_suspendCbSln) { return; }
@@ -456,6 +490,7 @@ namespace net.r_eg.DllExport.Wizard.UI
         private void btnApply_Click(object sender, EventArgs e)
         {
             exec.TargetsFileIfCfg?.Reset();
+            UpdateRefBefore();
 
             if(!SaveProjects(projectItems.Data)) {
                 return;
@@ -473,18 +508,14 @@ namespace net.r_eg.DllExport.Wizard.UI
 
         private void dgvFilter_RowEnter(object sender, DataGridViewCellEventArgs e)
         {
-            if(e.RowIndex == -1 || e.RowIndex >= dgvFilter.RowCount) {
-                return;
+            UpdateRefBefore();
+
+            IProject prj = GetProject(e.RowIndex);
+            if(prj != null) 
+            {
+                UpdateRefAfter(prj);
+                prevPrjIndex = e.RowIndex;
             }
-
-            string path     = dgvFilter.Rows[e.RowIndex].Cells[gcPath.Name].Value.ToString();
-            IProject prj    = GetProjects(exec.ActiveSlnFile).FirstOrDefault(p => p.ProjectPath == path);
-
-            projectItems.Pause();
-            projectItems.Set(prj);
-            projectItems.Resume();
-            
-            txtCfgData.Text = confFormater.Parse(prj);
         }
 
         private void dgvFilter_KeyDown(object sender, KeyEventArgs e)

--- a/Wizard/UI/ConfiguratorForm.cs
+++ b/Wizard/UI/ConfiguratorForm.cs
@@ -37,6 +37,7 @@ using net.r_eg.DllExport.NSBin;
 using net.r_eg.DllExport.Wizard.Extensions;
 using net.r_eg.DllExport.Wizard.UI.Extensions;
 using net.r_eg.DllExport.Wizard.UI.Kit;
+using net.r_eg.MvsSln.Extensions;
 using net.r_eg.MvsSln.Log;
 
 namespace net.r_eg.DllExport.Wizard.UI

--- a/Wizard/UI/Controls/PreProcControl.Designer.cs
+++ b/Wizard/UI/Controls/PreProcControl.Designer.cs
@@ -1,0 +1,196 @@
+﻿namespace net.r_eg.DllExport.Wizard.UI.Controls
+{
+    partial class PreProcControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if(disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.radioPreProcDisabled = new System.Windows.Forms.RadioButton();
+            this.linkPreProc = new System.Windows.Forms.LinkLabel();
+            this.linkAboutConari = new System.Windows.Forms.LinkLabel();
+            this.txtPreProc = new System.Windows.Forms.TextBox();
+            this.radioRawExec = new System.Windows.Forms.RadioButton();
+            this.radioILMerge = new System.Windows.Forms.RadioButton();
+            this.chkMergeConari = new System.Windows.Forms.CheckBox();
+            this.chkIgnoreErrors = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.chkGenDebugInfo = new System.Windows.Forms.CheckBox();
+            this.SuspendLayout();
+            // 
+            // radioPreProcDisabled
+            // 
+            this.radioPreProcDisabled.AutoSize = true;
+            this.radioPreProcDisabled.Checked = true;
+            this.radioPreProcDisabled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.radioPreProcDisabled.Location = new System.Drawing.Point(373, 51);
+            this.radioPreProcDisabled.Name = "radioPreProcDisabled";
+            this.radioPreProcDisabled.Size = new System.Drawing.Size(65, 17);
+            this.radioPreProcDisabled.TabIndex = 25;
+            this.radioPreProcDisabled.TabStop = true;
+            this.radioPreProcDisabled.Text = "Disabled";
+            this.toolTip1.SetToolTip(this.radioPreProcDisabled, "To disable Pre-Processing");
+            this.radioPreProcDisabled.UseVisualStyleBackColor = true;
+            this.radioPreProcDisabled.CheckedChanged += new System.EventHandler(this.RadioPreProcDisabled_CheckedChanged);
+            // 
+            // linkPreProc
+            // 
+            this.linkPreProc.AutoSize = true;
+            this.linkPreProc.Location = new System.Drawing.Point(6, 27);
+            this.linkPreProc.Name = "linkPreProc";
+            this.linkPreProc.Size = new System.Drawing.Size(13, 13);
+            this.linkPreProc.TabIndex = 24;
+            this.linkPreProc.TabStop = true;
+            this.linkPreProc.Text = "?";
+            this.linkPreProc.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkPreProc_LinkClicked);
+            // 
+            // linkAboutConari
+            // 
+            this.linkAboutConari.AutoSize = true;
+            this.linkAboutConari.Location = new System.Drawing.Point(88, 5);
+            this.linkAboutConari.Name = "linkAboutConari";
+            this.linkAboutConari.Size = new System.Drawing.Size(37, 13);
+            this.linkAboutConari.TabIndex = 23;
+            this.linkAboutConari.TabStop = true;
+            this.linkAboutConari.Text = "Conari";
+            this.toolTip1.SetToolTip(this.linkAboutConari, "Adds Conari inside final module for easy access to unmanaged features");
+            this.linkAboutConari.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkAboutConari_LinkClicked);
+            // 
+            // txtPreProc
+            // 
+            this.txtPreProc.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtPreProc.BackColor = System.Drawing.SystemColors.Control;
+            this.txtPreProc.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtPreProc.Enabled = false;
+            this.txtPreProc.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtPreProc.Location = new System.Drawing.Point(3, 74);
+            this.txtPreProc.Multiline = true;
+            this.txtPreProc.Name = "txtPreProc";
+            this.txtPreProc.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtPreProc.Size = new System.Drawing.Size(436, 150);
+            this.txtPreProc.TabIndex = 22;
+            // 
+            // radioRawExec
+            // 
+            this.radioRawExec.AutoSize = true;
+            this.radioRawExec.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.radioRawExec.Location = new System.Drawing.Point(25, 49);
+            this.radioRawExec.Name = "radioRawExec";
+            this.radioRawExec.Size = new System.Drawing.Size(97, 17);
+            this.radioRawExec.TabIndex = 20;
+            this.radioRawExec.Text = "Exec command";
+            this.toolTip1.SetToolTip(this.radioRawExec, "Execute command via <Exec Command=\"...your code below...\" WorkingDirectory=\"$(Tar" +
+        "getDir)\" />\"");
+            this.radioRawExec.UseVisualStyleBackColor = true;
+            this.radioRawExec.CheckedChanged += new System.EventHandler(this.RadioRawExec_CheckedChanged);
+            // 
+            // radioILMerge
+            // 
+            this.radioILMerge.AutoSize = true;
+            this.radioILMerge.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.radioILMerge.Location = new System.Drawing.Point(25, 27);
+            this.radioILMerge.Name = "radioILMerge";
+            this.radioILMerge.Size = new System.Drawing.Size(155, 17);
+            this.radioILMerge.TabIndex = 19;
+            this.radioILMerge.Text = "Merge modules via ILMerge";
+            this.toolTip1.SetToolTip(this.radioILMerge, "Separated by a whitespace char: Module1 Module2 ...");
+            this.radioILMerge.UseVisualStyleBackColor = true;
+            this.radioILMerge.CheckedChanged += new System.EventHandler(this.RadioILMerge_CheckedChanged);
+            // 
+            // chkMergeConari
+            // 
+            this.chkMergeConari.AutoSize = true;
+            this.chkMergeConari.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.chkMergeConari.Location = new System.Drawing.Point(25, 4);
+            this.chkMergeConari.Name = "chkMergeConari";
+            this.chkMergeConari.Size = new System.Drawing.Size(66, 17);
+            this.chkMergeConari.TabIndex = 18;
+            this.chkMergeConari.Text = "Integrate";
+            this.toolTip1.SetToolTip(this.chkMergeConari, "Adds Conari inside final module for easy access to unmanaged features");
+            this.chkMergeConari.UseVisualStyleBackColor = true;
+            this.chkMergeConari.CheckedChanged += new System.EventHandler(this.ChkMergeConari_CheckedChanged);
+            // 
+            // chkIgnoreErrors
+            // 
+            this.chkIgnoreErrors.AutoSize = true;
+            this.chkIgnoreErrors.Enabled = false;
+            this.chkIgnoreErrors.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.chkIgnoreErrors.Location = new System.Drawing.Point(186, 49);
+            this.chkIgnoreErrors.Name = "chkIgnoreErrors";
+            this.chkIgnoreErrors.Size = new System.Drawing.Size(82, 17);
+            this.chkIgnoreErrors.TabIndex = 26;
+            this.chkIgnoreErrors.Text = "Ignore errors";
+            this.chkIgnoreErrors.UseVisualStyleBackColor = true;
+            // 
+            // chkGenDebugInfo
+            // 
+            this.chkGenDebugInfo.AutoSize = true;
+            this.chkGenDebugInfo.Enabled = false;
+            this.chkGenDebugInfo.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.chkGenDebugInfo.Location = new System.Drawing.Point(186, 27);
+            this.chkGenDebugInfo.Name = "chkGenDebugInfo";
+            this.chkGenDebugInfo.Size = new System.Drawing.Size(120, 17);
+            this.chkGenDebugInfo.TabIndex = 27;
+            this.chkGenDebugInfo.Text = "Generate debug info";
+            this.chkGenDebugInfo.UseVisualStyleBackColor = true;
+            // 
+            // PreProcControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.chkGenDebugInfo);
+            this.Controls.Add(this.chkIgnoreErrors);
+            this.Controls.Add(this.radioPreProcDisabled);
+            this.Controls.Add(this.linkPreProc);
+            this.Controls.Add(this.linkAboutConari);
+            this.Controls.Add(this.txtPreProc);
+            this.Controls.Add(this.radioRawExec);
+            this.Controls.Add(this.radioILMerge);
+            this.Controls.Add(this.chkMergeConari);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.Name = "PreProcControl";
+            this.Size = new System.Drawing.Size(441, 227);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.RadioButton radioPreProcDisabled;
+        private System.Windows.Forms.LinkLabel linkPreProc;
+        private System.Windows.Forms.LinkLabel linkAboutConari;
+        private System.Windows.Forms.TextBox txtPreProc;
+        private System.Windows.Forms.RadioButton radioRawExec;
+        private System.Windows.Forms.RadioButton radioILMerge;
+        private System.Windows.Forms.CheckBox chkMergeConari;
+        private System.Windows.Forms.CheckBox chkIgnoreErrors;
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.CheckBox chkGenDebugInfo;
+    }
+}

--- a/Wizard/UI/Controls/PreProcControl.cs
+++ b/Wizard/UI/Controls/PreProcControl.cs
@@ -1,0 +1,110 @@
+﻿/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016-2020  Denis Kuzmin < x-3F@outlook.com > GitHub/3F
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using net.r_eg.DllExport.Wizard.Extensions;
+using static net.r_eg.DllExport.Wizard.PreProc;
+
+namespace net.r_eg.DllExport.Wizard.UI.Controls
+{
+    internal partial class PreProcControl: UserControl
+    {
+        public CmdType Type => GetCmdType();
+
+        public string Cmd => txtPreProc.Text;
+
+        public void Render(PreProc instance)
+        {
+            if(instance == null) {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            SetCmdType(instance.Type);
+            txtPreProc.Text = instance.Cmd;
+        }
+
+        public PreProc Export(PreProc obj) 
+            => (obj ?? throw new ArgumentNullException(nameof(obj))).Configure(Type, Cmd);
+
+        public PreProcControl() => InitializeComponent();
+
+        private void SetCmdType(CmdType type)
+        {
+            if(type == CmdType.None)
+            {
+                radioPreProcDisabled.Checked = true; 
+                return;
+            }
+
+            if((type & CmdType.ILMerge) == CmdType.ILMerge) { radioILMerge.Checked = true; }
+            if((type & CmdType.Exec) == CmdType.Exec)       { radioRawExec.Checked = true; }
+
+            chkMergeConari.Checked  = ((type & CmdType.Conari) == CmdType.Conari);
+            chkIgnoreErrors.Checked = ((type & CmdType.IgnoreErr) == CmdType.IgnoreErr);
+            chkGenDebugInfo.Checked = ((type & CmdType.DebugInfo) == CmdType.DebugInfo);
+        }
+
+        private CmdType GetCmdType()
+        {
+            CmdType ret = CmdType.None;
+
+            if(radioILMerge.Checked) { ret = CmdType.ILMerge; }
+            if(radioRawExec.Checked) { ret = CmdType.Exec; }
+
+            if(chkMergeConari.Checked)  { ret |= CmdType.Conari; }
+            if(chkIgnoreErrors.Checked) { ret |= CmdType.IgnoreErr; }
+            if(chkGenDebugInfo.Checked) { ret |= CmdType.DebugInfo; }
+
+            return ret;
+        }
+
+        private void SetUIMergeConari(bool disabled)
+        {
+            if(disabled) chkMergeConari.Checked = false;
+        }
+
+        private bool SetUIPreProcCmd(bool disabled)
+        {
+            txtPreProc.Enabled      = !disabled;
+            txtPreProc.BackColor    = (disabled) ? SystemColors.Control : SystemColors.Window;
+
+            chkIgnoreErrors.Checked = chkIgnoreErrors.Enabled
+                                    = !disabled;
+            return disabled;
+        }
+
+        private void ChkMergeConari_CheckedChanged(object sender, EventArgs e)
+        {
+            if(chkMergeConari.Checked) radioILMerge.Checked = true;
+        }
+
+        private void RadioPreProcDisabled_CheckedChanged(object sender, EventArgs e) => SetUIMergeConari(SetUIPreProcCmd(radioPreProcDisabled.Checked));
+        private void RadioRawExec_CheckedChanged(object sender, EventArgs e) => SetUIMergeConari(radioRawExec.Checked);
+        private void LinkAboutConari_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => "https://github.com/3F/DllExport/wiki/Quick-start#when-conari-can-help-you".OpenUrl();
+        private void LinkPreProc_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => "https://github.com/3F/DllExport/issues/40".OpenUrl();
+        private void RadioILMerge_CheckedChanged(object sender, EventArgs e) => chkGenDebugInfo.Checked = chkGenDebugInfo.Enabled = radioILMerge.Checked;
+    }
+}

--- a/Wizard/UI/Controls/PreProcControl.resx
+++ b/Wizard/UI/Controls/PreProcControl.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Wizard/UI/Controls/ProjectItemsControl.cs
+++ b/Wizard/UI/Controls/ProjectItemsControl.cs
@@ -121,7 +121,7 @@ namespace net.r_eg.DllExport.Wizard.UI.Controls
         public IEnumerable<IProject> GetInactiveInstalled(IEnumerable<IProject> projects)
         {
             return projects?.Where(p => p.Installed && Data.All(d => d.DxpIdent != p.DxpIdent))
-                            .ForEach(p => p.Config.Install = true); // since we're not using ConfigureProject()
+                            .Each(p => p.Config.Install = true); // since we're not using ConfigureProject()
         }
 
         public ProjectItemsControl()

--- a/Wizard/Wizard.csproj
+++ b/Wizard/Wizard.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IProjectSvc.cs" />
     <Compile Include="MSBuildTargets.cs" />
     <Compile Include="Extensions\ThreadingExtension.cs" />
     <Compile Include="PackageInfo.cs" />
@@ -73,6 +74,8 @@
     <Compile Include="CompilerCfg.cs" />
     <Compile Include="MSBuildProperties.cs" />
     <Compile Include="DxpIsolatedEnv.cs" />
+    <Compile Include="Gears\IProjectGear.cs" />
+    <Compile Include="Gears\PreProcGear.cs" />
     <Compile Include="PreProc.cs" />
     <Compile Include="Platform.cs" />
     <Compile Include="IProject.cs" />

--- a/Wizard/Wizard.csproj
+++ b/Wizard/Wizard.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MSBuildTargets.cs" />
     <Compile Include="Extensions\ThreadingExtension.cs" />
     <Compile Include="PackageInfo.cs" />
     <Compile Include="Caller.cs" />
@@ -72,6 +73,7 @@
     <Compile Include="CompilerCfg.cs" />
     <Compile Include="MSBuildProperties.cs" />
     <Compile Include="DxpIsolatedEnv.cs" />
+    <Compile Include="PreProc.cs" />
     <Compile Include="Platform.cs" />
     <Compile Include="IProject.cs" />
     <Compile Include="ITargetsFile.cs" />
@@ -88,6 +90,12 @@
     </Compile>
     <Compile Include="UI\Components\DataGridViewExt.cs">
       <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="UI\Controls\PreProcControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UI\Controls\PreProcControl.Designer.cs">
+      <DependentUpon>PreProcControl.cs</DependentUpon>
     </Compile>
     <Compile Include="UI\IConfFormater.cs" />
     <Compile Include="UI\IconResources.Designer.cs">
@@ -175,6 +183,9 @@
     <EmbeddedResource Include="UI\ConfiguratorForm.resx">
       <DependentUpon>ConfiguratorForm.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\Controls\PreProcControl.resx">
+      <DependentUpon>PreProcControl.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\IconResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
Closes #40

After serial questions about manipulation for modules together with our tool and some misunderstanding such for "How do I do this without the /ndebug flag" https://twitter.com/GitHub3F/status/1248621686930337795

I decided to add configurable Pre-Processing where we can configure like ILMerge, Conari, and others.

"WIP" since PackageReference is missing copy files to output if .NET Core/SDK-style
* https://github.com/NuGet/Home/issues/4837

But `GeneratePathProperty` feature https://github.com/NuGet/Home/issues/4837#issuecomment-474184722 will require additional processing to find related platform:

```xml

<PackageReference Include="Conari" Version="1.4.0" GeneratePathProperty="true" />
...
<Copy SourceFiles="$(PkgConari)\lib\netstandard2.0\Conari.dll" DestinationFolder="$(OutDir)" />
```
Thus `CopyLocalLockFileAssemblies` still is more suitable for this case. But I'm still not sure, I'll try to review this later.